### PR TITLE
記事並べ・ヘッダー・作成画面背景・フラッシュ

### DIFF
--- a/src/app/Models/Board.php
+++ b/src/app/Models/Board.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory; 
 use Illuminate\Database\Eloquent\Model;
 
 class Board extends Model

--- a/src/resources/views/boards/create.blade.php
+++ b/src/resources/views/boards/create.blade.php
@@ -1,7 +1,13 @@
 <x-app-layout>
-  <div class="bg-white w-full h-screen">
     <div class="w-1/2 mx-auto pt-6 px-8 pb-8">
-      <h1 class="text-4xl">掲示板作成</h1>
+      <h1 class="text-4xl">記事作成</h1>
+      @if ($errors->any())
+          <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+              @foreach ($errors->all() as $error)
+                  <li>{{ $error }}</li>
+              @endforeach
+          </div>
+      @endif
       <form class="rounded mb-4" method="POST" action="{{ route('boards.store') }}">
         @csrf
         <div class="mb-4">

--- a/src/resources/views/boards/index.blade.php
+++ b/src/resources/views/boards/index.blade.php
@@ -1,18 +1,23 @@
 <x-app-layout>
-  <div class="m-3 mx-32 grid grid-cols-3 gap-4 flex flex-wrap flex-row">
-    @foreach ($boards as $board) <div
-      class="bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700">
-      <a href="#">
-        <img class="rounded-t-lg" src="https://flowbite.com/docs/images/blog/image-1.jpg" alt="" />
-      </a>
-      <div class="p-5">
-        <a href="#">
-          <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">{{ $board->title }}</h5>
-        </a>
-        <p>by {{ $board->user->name }}</p>
-        <p class="my-3 font-normal text-gray-700 dark:text-gray-400 break-words">{{ $board->description }}</p>
+  <x-slot name="header">
+    <h2 class="text-xl font-semibold leading-tight text-gray-800">
+      {{ __('投稿記事一覧') }}
+    </h2>
+  </x-slot>
+
+  <div class="max-w-4xl mx-auto space-y-4 mt-6">  <!-- 投稿ならべてるやつ -->
+    @foreach ($boards as $board)
+      <div class="p-4 border rounded shadow-sm bg-white dark:bg-gray-800">
+        <h5 class="mt-3 mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+          {{ $board->title }}
+        </h5>
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+          by {{ $board->user->name }}
+        </p>
+        <p class="my-3 font-normal text-gray-700 dark:text-gray-400 break-words">
+          {{ $board->description }}
+        </p>
       </div>
-    </div>
     @endforeach
   </div>
 </x-app-layout>

--- a/src/resources/views/layouts/navigation.blade.php
+++ b/src/resources/views/layouts/navigation.blade.php
@@ -37,10 +37,10 @@
           </x-slot>
           <x-slot name="content">
             <x-dropdown-link :href="route('boards.index')">
-              {{ __('掲示板一覧') }}
+              {{ __('記事一覧') }}
             </x-dropdown-link>
             <x-dropdown-link :href="route('boards.create')">
-              {{ __('掲示板作成') }}
+              {{ __('記事作成') }}
             </x-dropdown-link>
           </x-slot>
         </x-dropdown>


### PR DESCRIPTION
・作成した記事のサムネの写真消して、ツイッターみたいに並べれるようにした
・記事作成画面に背景の色当てた
・記事作成時のフラッシュメッセージ出るようにした（エラーだけ）
・記事一覧画面にヘッダーつけた