### PR TITLE
ページネーションと戻るボタンの遷移先変更

### DIFF
--- a/src/app/Http/Controllers/BoardController.php
+++ b/src/app/Http/Controllers/BoardController.php
@@ -15,10 +15,10 @@ class BoardController extends Controller
 
    public function index()
 {
-    $boards = Board::latest()->get();
+    $boards = Board::latest()->paginate(10);
     $converter = new CommonMarkConverter();
 
-    $boards->map(function ($board) use ($converter) {
+    $boards->getCollection()->transform(function ($board) use ($converter) {
         $board->description_html = $converter->convert($board->description ?? '')->getContent();
         return $board;
     });

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -20,7 +20,7 @@ public function mypage()
 {
     $boards = \App\Models\Board::where('user_id', auth()->id())
         ->latest()
-        ->get();
+        ->paginate(10);
 
     return view('mypage', compact('boards'));
 }

--- a/src/resources/views/boards/index.blade.php
+++ b/src/resources/views/boards/index.blade.php
@@ -92,6 +92,9 @@
  
       </div>
     @endforeach
+    <div class="mt-4">
+        {{ $boards->links() }}
+    </div>
   </div>
 </x-app-layout>
 

--- a/src/resources/views/boards/show.blade.php
+++ b/src/resources/views/boards/show.blade.php
@@ -2,6 +2,12 @@
 <x-app-layout>
   <div class="max-w-5xl mx-auto space-y-6 mt-6 px-4">
 
+        <!-- 戻るボタン -->
+      <div class="mt-4">
+        <a href="{{ route('boards.index') }}" class="text-white hover:underline">＜ 一覧へ戻る</a>
+      </div>
+
+
     <div class="p-6 border rounded-2xl shadow-lg bg-white dark:bg-gray-800">
       
       <!-- タイトル -->
@@ -85,12 +91,6 @@
           </form>
         </div>
       @endif
-
-      <!-- 戻るボタン -->
-      <div class="mt-4">
-        <a href="{{ url()->previous() }}" class="text-green-500 hover:underline">戻る</a>
-      </div>
-
     </div>
 
     <!-- コメントセクション -->

--- a/src/resources/views/mypage.blade.php
+++ b/src/resources/views/mypage.blade.php
@@ -81,6 +81,9 @@
               </div>
             </div>
           @endforeach
+          <div class="mt-4">
+              {{ $boards->links() }}
+          </div>
         </div>
       @else
         <div class="text-gray-500 mt-8">


### PR DESCRIPTION
記事一覧ページとマイページに表示される記事一覧に10件単位のページネーションをかけました。
あと記事詳細画面の戻るボタンを一つ前に戻るのではなく、記事一覧画面に遷移するようにしました。