### PR TITLE
マイページの切り替えなめらか

### DIFF
--- a/src/resources/views/dashboard.blade.php
+++ b/src/resources/views/dashboard.blade.php
@@ -23,26 +23,29 @@
     {{-- コンテンツ部分 --}}
         <div class="container mx-auto px-4 py-8">
         <!-- 切り替えボタン -->
-        <div class="tabs flex justify-center gap-6 mb-6">
-             <span class="text-5xl">🍎</span>
-             <span class="text-5xl">🍎</span>
-        <x-primary-button onclick="loadBoards('latest')" 
-            class="text-xl px-12 py-4"
+    <div class="tabs flex justify-center gap-6 mb-6">
+        <span class="text-5xl">🍎</span>
+        <span class="text-5xl">🍎</span>
+        <x-primary-button 
+            onclick="loadBoards('latest')" 
+            class="tab-button text-xl px-12 py-4"
             id="btn-latest">
             最新
         </x-primary-button>
-        <x-primary-button onclick="loadBoards('popular')" 
-            class="text-xl px-12 py-4"
+        <x-primary-button 
+            onclick="loadBoards('popular')" 
+            class="tab-button text-xl px-12 py-4"
             id="btn-popular">
             人気
         </x-primary-button>
-        <x-primary-button onclick="loadBoards('views')" 
-            class="text-xl px-12 py-4"
+        <x-primary-button 
+            onclick="loadBoards('views')" 
+            class="tab-button text-xl px-12 py-4"
             id="btn-views">
             閲覧
         </x-primary-button>
-         <span class="text-5xl">🍎</span>
-         <span class="text-5xl">🍎</span>
+        <span class="text-5xl">🍎</span>
+        <span class="text-5xl">🍎</span>
     </div>
 
         <div id="ranking-container"></div>
@@ -55,88 +58,105 @@
      {{-- JS --}}
     <script>
         function loadBoards(type) {
-            fetch(`/boards/ranking/${type}`)
-                .then(res => res.json())
-                .then(data => {
-                    const container = document.getElementById('boards-container');
-                    container.innerHTML = ''; // 一旦クリア
+    fetch(`/boards/ranking/${type}`)
+        .then(res => res.json())
+        .then(data => {
+            const container = document.getElementById('boards-container');
+            container.innerHTML = ''; // 一旦クリア
 
-                    data.forEach((board, index) => {
-                            let rankMark = '';
-                            if (index === 0) rankMark = '🥇';  // 1位
-                            else if (index === 1) rankMark = '🥈';  // 2位
-                            else if (index === 2) rankMark = '🥉';  // 3位
-                        
-                        let profileImgHtml = '';
-                        if (board.user.profile_image) {
-                            profileImgHtml = `
-                                 <img src="/storage/${board.user.profile_image}" 
-                                      alt="Profile Image" 
-                                      class="w-16 h-16 rounded-full object-cover mr-3" />
-                            `;
-                        } else {
-                            profileImgHtml = `
-                                 <div class="w-16 h-16 rounded-full bg-gray-300 flex items-center justify-center mr-3">
-                                    <span class="text-gray-500 text-sm">No Image</span>
-                                 </div>
-                            `;
-                        }
+            data.forEach((board, index) => {
+                let rankMark = '';
+                if (index === 0) rankMark = '🥇';
+                else if (index === 1) rankMark = '🥈';
+                else if (index === 2) rankMark = '🥉';
 
-                        container.innerHTML += `
-                          <div class="board-item border p-4 rounded shadow bg-white flex items-center justify-between gap-4">
-                            <div>
-                              <span class="rank-mark text-xl">${rankMark}</span>
-                              <h3 class="text-lg font-semibold">
-                                <a href="${board.detail_url}" class="text-orange-600 hover:underline">
-                                  ${board.title}
-                                </a>
-                              </h3>
-                              <p>
-                                投稿者: ${board.user.name}
-                                ${board.user.is_runteq_student ? '<span">🍎</span>' : ''}
-                              </p>
-                              <p>いいね: ${board.likes_count} | 閲覧: ${board.view_count}</p>
-                              <p>投稿日: ${new Date(board.created_at).toLocaleDateString()}</p>
-                            </div>
-                            <div class="flex flex-col justify-end items-end">
-                              ${profileImgHtml}
-                            </div>
-                          </div>
-                        `;
-                    });
+                let profileImgHtml = '';
+                if (board.user.profile_image) {
+                    profileImgHtml = `
+                         <img src="/storage/${board.user.profile_image}" 
+                              alt="Profile Image" 
+                              class="w-16 h-16 rounded-full object-cover mr-3" />
+                    `;
+                } else {
+                    profileImgHtml = `
+                         <div class="w-16 h-16 rounded-full bg-gray-300 flex items-center justify-center mr-3">
+                            <span class="text-gray-500 text-sm">No Image</span>
+                         </div>
+                    `;
+                }
 
-                    // ボタンの active クラス切り替え
-                    document.querySelectorAll('.tab-button').forEach(btn => btn.classList.remove('active'));
-                    document.getElementById(`btn-${type}`).classList.add('active');
-                })
-                .catch(() => {
-                    alert('ランキングの読み込みに失敗しました');
-                });
-        }
+                container.innerHTML += `
+                  <div class="board-item border p-4 rounded shadow bg-white flex items-center justify-between gap-4">
+                    <div>
+                      <span class="rank-mark text-xl">${rankMark}</span>
+                      <h3 class="text-lg font-semibold">
+                        <a href="${board.detail_url}" class="text-orange-600 hover:underline">
+                          ${board.title}
+                        </a>
+                      </h3>
+                      <p>
+                        投稿者: ${board.user.name}
+                        ${board.user.is_runteq_student ? '<span>🍎</span>' : ''}
+                      </p>
+                      <p>いいね: ${board.likes_count} | 閲覧: ${board.view_count}</p>
+                      <p>投稿日: ${new Date(board.created_at).toLocaleDateString()}</p>
+                    </div>
+                    <div class="flex flex-col justify-end items-end">
+                      ${profileImgHtml}
+                    </div>
+                  </div>
+                `;
+            });
 
-        // ページ読み込み時に最新を表示
-        document.addEventListener('DOMContentLoaded', () => loadBoards('latest'));
+            // ここで active クラスを付ける（色を変える）
+            document.querySelectorAll('.tab-button').forEach(btn => {
+                btn.classList.remove('active', 'bg-blue-600', 'text-white');
+            });
+            const activeBtn = document.getElementById(`btn-${type}`);
+            if (activeBtn) {
+                activeBtn.classList.add('active', 'bg-blue-600', 'text-white');
+            }
+        })
+        .catch(() => {
+            alert('ランキングの読み込みに失敗しました');
+        });
+    }
+
     </script>
 
     @push('styles')
     <style>
         .tab-button {
-            padding: 10px 20px;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem; /* Tailwindの gap-2 = 0.5rem */
+            padding: 1rem 1.75rem; 
+            font-size: 1.125rem; 
+            font-weight: 600; /* font-semibold */
+            color: white;
+            background-color: #fb923c; /* Tailwind orange-400 (#fb923c) */
+            border-radius: 9999px; /* rounded-full */
+            box-shadow: 0 4px 6px rgba(0,0,0,0.1); /* shadow-md相当 */
             border: none;
-            background: #eee;
             cursor: pointer;
-            border-radius: 4px;
-            transition: background-color 0.2s;
+            transition: all 0.2s ease-in-out;
+            outline: none;
+        }
+
+        .tab-button:hover {
+            background-color: #f97316; /* orange-500 */
+            transform: scale(1.05);
+        }
+
+        .tab-button:focus {
+            outline: none;
         }
 
         .tab-button.active {
-            background-color: #f97316;
+            background-color: #ea580c; /* ちょっと濃いオレンジ */
             color: white;
-        }
-
-        .board-card h3 {
-            margin: 0 0 5px;
         }
     </style>
     @endpush
-</x-app-layout>
+
+    </x-app-layout>

--- a/src/resources/views/mypage.blade.php
+++ b/src/resources/views/mypage.blade.php
@@ -62,115 +62,137 @@
 
     {{-- 切り替えボタン --}}
 <div class="tabs flex justify-center gap-6 mb-6">
-     <span class="text-5xl">🍎</span>
-     <span class="text-5xl">🍎</span>
-    <a href="{{ route('mypage', ['view' => 'own']) }}">
-        <x-primary-button class="text-xl px-12 py-4 {{ $viewMode === 'own' ? 'bg-blue-600 text-white' : '' }}">
-            自分の投稿
-        </x-primary-button>
-    </a>
+    <span class="text-5xl">🍎</span>
+    <span class="text-5xl">🍎</span>
 
-    <a href="{{ route('mypage', ['view' => 'likes']) }}">
-        <x-primary-button class="text-xl px-12 py-4 {{ $viewMode === 'likes' ? 'bg-blue-600 text-white' : '' }}">
-            いいねした記事
-        </x-primary-button>
-    </a>
-      <span class="text-5xl">🍎</span>
-      <span class="text-5xl">🍎</span>
+    <button id="ownTabButton"
+        class="text-xl px-12 py-4 border rounded-xl transition-all tab-button {{ $viewMode === 'own' ? 'bg-blue-600 text-white' : '' }}">
+        自分の投稿
+    </button>
+
+    <button id="likesTabButton"
+        class="text-xl px-12 py-4 border rounded-xl transition-all tab-button {{ $viewMode === 'likes' ? 'bg-blue-600 text-white' : '' }}">
+        いいねした記事
+    </button>
+
+    <span class="text-5xl">🍎</span>
+    <span class="text-5xl">🍎</span>
 </div>
 
    {{-- 投稿一覧表示 --}}
-      @if ($viewMode === 'own')
+      <div id="ownPosts" style="{{ $viewMode === 'own' ? '' : 'display:none;' }}">
         {{-- 自分の投稿 --}}
-        @if ($boards->isNotEmpty())
-          @foreach ($boards as $board)
-            <div class="border rounded-2xl shadow-md p-6 mb-6 bg-white">
-              <h2 class="text-2xl font-semibold text-gray-800 mb-2">{{ $board->title }}</h2>
-              <div class="text-sm text-gray-500 mb-4">
-                投稿者: {{ $board->user->name ?? '不明' }}
-                投稿日: {{ $board->created_at->format('Y/m/d H:i') }}
-              </div>
-              <div class="prose prose-gray max-w-none">
-              @php
-                // 画像だけ除去
-                $htmlWithoutImages = preg_replace('/<img[^>]*>/', '', $board->description_html ?? '');
+            @if ($boards->isNotEmpty())
+              @foreach ($boards as $board)
+                <div class="border rounded-2xl shadow-md p-6 mb-6 bg-white">
+                  <h2 class="text-2xl font-semibold text-gray-800 mb-2">{{ $board->title }}</h2>
+                  <div class="text-sm text-gray-500 mb-4">
+                    投稿者: {{ $board->user->name ?? '不明' }}
+                    投稿日: {{ $board->created_at->format('Y/m/d H:i') }}
+                  </div>
+                  <div class="prose prose-gray max-w-none">
+                  @php
+                    // 画像だけ除去
+                    $htmlWithoutImages = preg_replace('/<img[^>]*>/', '', $board->description_html ?? '');
 
-                // プレーンテキストに変換（タグ除去）
-                $plainDescription = strip_tags($htmlWithoutImages);
+                    // プレーンテキストに変換（タグ除去）
+                    $plainDescription = strip_tags($htmlWithoutImages);
 
-                // 表示する最大文字数
-                $maxLength = 100;
+                    // 表示する最大文字数
+                    $maxLength = 100;
 
-                // 短縮された本文（必要なら）
-                $shortDescription = Str::limit($plainDescription, $maxLength);
-              @endphp
+                    // 短縮された本文（必要なら）
+                    $shortDescription = Str::limit($plainDescription, $maxLength);
+                  @endphp
 
-              {{ $shortDescription }}
+                  {{ $shortDescription }}
 
-              @if (Str::length($plainDescription) > $maxLength)
-                <a href="{{ route('boards.show', $board->id) }}" class="text-orange-500 hover:underline ml-1">続きを読む</a>
-              @endif
-            </div>
+                  @if (Str::length($plainDescription) > $maxLength)
+                    <a href="{{ route('boards.show', $board->id) }}" class="text-orange-500 hover:underline ml-1">続きを読む</a>
+                  @endif
+                </div>
 
-              <div class="mt-4 flex items-center gap-4">
-                <span class="text-sm text-gray-600">💖 {{ $board->likes_count ?? 0 }} 件のいいね</span>
-                @if (route('boards.show', $board->id, false))
-                  <a href="{{ route('boards.show', $board->id) }}" class="text-green-600 hover:underline text-sm">詳細を見る</a>
-                @endif
-              </div>
-            </div>
-          @endforeach
-          <div class="mt-4">{{ $boards->links() }}</div>
-        @else
-          <p class="text-gray-500 text-center">あなたの投稿はまだありません。</p>
-        @endif
+                  <div class="mt-4 flex items-center gap-4">
+                    <span class="text-sm text-gray-600">💖 {{ $board->likes_count ?? 0 }} 件のいいね</span>
+                    @if (route('boards.show', $board->id, false))
+                      <a href="{{ route('boards.show', $board->id) }}" class="text-green-600 hover:underline text-sm">詳細を見る</a>
+                    @endif
+                  </div>
+                </div>
+              @endforeach
+              <div class="mt-4">{{ $boards->links() }}</div>
+            @else
+              <p class="text-gray-500 text-center">あなたの投稿はまだありません。</p>
+            @endif
+    </div>
 
-      @elseif ($viewMode === 'likes')
+    <div id="likedPosts" style="{{ $viewMode === 'likes' ? '' : 'display:none;' }}">
         {{-- お気に入り --}}
-        @if ($likedBoards->isNotEmpty())
-          @foreach ($likedBoards as $board)
-            <div class="border rounded-2xl shadow-md p-6 mb-6 bg-white">
-              <h2 class="text-2xl font-semibold text-gray-800 mb-2">{{ $board->title }}</h2>
-              <div class="text-sm text-gray-500 mb-4">
-                投稿者: {{ $board->user->name ?? '不明' }}
-                投稿日: {{ $board->created_at->format('Y/m/d H:i') }}
-              </div>
-              <div class="prose prose-gray max-w-none">
-              @php
-                // 画像だけ除去
-                $htmlWithoutImages = preg_replace('/<img[^>]*>/', '', $board->description_html ?? '');
+            @if ($likedBoards->isNotEmpty())
+              @foreach ($likedBoards as $board)
+                <div class="border rounded-2xl shadow-md p-6 mb-6 bg-white">
+                  <h2 class="text-2xl font-semibold text-gray-800 mb-2">{{ $board->title }}</h2>
+                  <div class="text-sm text-gray-500 mb-4">
+                    投稿者: {{ $board->user->name ?? '不明' }}
+                    投稿日: {{ $board->created_at->format('Y/m/d H:i') }}
+                  </div>
+                  <div class="prose prose-gray max-w-none">
+                  @php
+                    // 画像だけ除去
+                    $htmlWithoutImages = preg_replace('/<img[^>]*>/', '', $board->description_html ?? '');
 
-                // プレーンテキストに変換（タグ除去）
-                $plainDescription = strip_tags($htmlWithoutImages);
+                    // プレーンテキストに変換（タグ除去）
+                    $plainDescription = strip_tags($htmlWithoutImages);
 
-                // 表示する最大文字数
-                $maxLength = 100;
+                    // 表示する最大文字数
+                    $maxLength = 100;
 
-                // 短縮された本文（必要なら）
-                $shortDescription = Str::limit($plainDescription, $maxLength);
-              @endphp
+                    // 短縮された本文（必要なら）
+                    $shortDescription = Str::limit($plainDescription, $maxLength);
+                  @endphp
 
-              {{ $shortDescription }}
+                  {{ $shortDescription }}
 
-              @if (Str::length($plainDescription) > $maxLength)
-                <a href="{{ route('boards.show', $board->id) }}" class="text-orange-500 hover:underline ml-1">続きを読む</a>
-              @endif
-            </div>
+                  @if (Str::length($plainDescription) > $maxLength)
+                    <a href="{{ route('boards.show', $board->id) }}" class="text-orange-500 hover:underline ml-1">続きを読む</a>
+                  @endif
+                </div>
 
-              <div class="mt-4 flex items-center gap-4">
-                <span class="text-sm text-gray-600">💖 {{ $board->likes_count ?? 0 }} 件のいいね</span>
-                @if (route('boards.show', $board->id, false))
-                  <a href="{{ route('boards.show', $board->id) }}" class="text-green-600 hover:underline text-sm">詳細を見る</a>
-                @endif
-              </div>
-            </div>
-          @endforeach
-        @else
-          <p class="text-gray-500 text-center">お気に入りの投稿はまだありません。</p>
-        @endif
-      @endif
-
+                  <div class="mt-4 flex items-center gap-4">
+                    <span class="text-sm text-gray-600">💖 {{ $board->likes_count ?? 0 }} 件のいいね</span>
+                    @if (route('boards.show', $board->id, false))
+                      <a href="{{ route('boards.show', $board->id) }}" class="text-green-600 hover:underline text-sm">詳細を見る</a>
+                    @endif
+                  </div>
+                </div>
+              @endforeach
+            @else
+              <p class="text-gray-500 text-center">お気に入りの投稿はまだありません。</p>
+            @endif
     </div>
   </div>
+  </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const ownButton = document.getElementById('ownTabButton');
+        const likesButton = document.getElementById('likesTabButton');
+        const ownPosts = document.getElementById('ownPosts');
+        const likedPosts = document.getElementById('likedPosts');
+
+        ownButton.addEventListener('click', function () {
+            ownPosts.style.display = 'block';
+            likedPosts.style.display = 'none';
+            ownButton.classList.add('bg-blue-600', 'text-white');
+            likesButton.classList.remove('bg-blue-600', 'text-white');
+        });
+
+        likesButton.addEventListener('click', function () {
+            ownPosts.style.display = 'none';
+            likedPosts.style.display = 'block';
+            likesButton.classList.add('bg-blue-600', 'text-white');
+            ownButton.classList.remove('bg-blue-600', 'text-white');
+        });
+    });
+</script>
   
 </x-app-layout>

--- a/src/resources/views/mypage.blade.php
+++ b/src/resources/views/mypage.blade.php
@@ -65,15 +65,15 @@
     <span class="text-5xl">🍎</span>
     <span class="text-5xl">🍎</span>
 
-    <button id="ownTabButton"
-        class="text-xl px-12 py-4 border rounded-xl transition-all tab-button {{ $viewMode === 'own' ? 'bg-blue-600 text-white' : '' }}">
-        自分の投稿
-    </button>
+<x-primary-button 
+  class="tab-button" id="ownTabButton">
+  自分の投稿
+</x-primary-button>
 
-    <button id="likesTabButton"
-        class="text-xl px-12 py-4 border rounded-xl transition-all tab-button {{ $viewMode === 'likes' ? 'bg-blue-600 text-white' : '' }}">
+    <x-primary-button id="likesTabButton"
+        class="text-xl px-12 py-4 border transition-all tab-button {{ $viewMode === 'likes' ? 'bg-blue-600 text-white' : '' }}">
         いいねした記事
-    </button>
+    </x-primary-button>
 
     <span class="text-5xl">🍎</span>
     <span class="text-5xl">🍎</span>
@@ -174,25 +174,81 @@
   </div>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
-        const ownButton = document.getElementById('ownTabButton');
-        const likesButton = document.getElementById('likesTabButton');
-        const ownPosts = document.getElementById('ownPosts');
-        const likedPosts = document.getElementById('likedPosts');
+    const ownButton = document.getElementById('ownTabButton');
+    const likesButton = document.getElementById('likesTabButton');
+    const ownPosts = document.getElementById('ownPosts');
+    const likedPosts = document.getElementById('likedPosts');
 
-        ownButton.addEventListener('click', function () {
+    function setActive(button) {
+        // まず非表示にして、activeクラスを外す
+        ownPosts.style.display = 'none';
+        likedPosts.style.display = 'none';
+
+        ownButton.classList.remove('active', 'bg-blue-600', 'text-white');
+        likesButton.classList.remove('active', 'bg-blue-600', 'text-white');
+
+        // クリックされたボタンを active にして
+        button.classList.add('active', 'bg-blue-600', 'text-white');
+
+        // 対応するコンテンツだけ表示
+        if (button === ownButton) {
             ownPosts.style.display = 'block';
-            likedPosts.style.display = 'none';
-            ownButton.classList.add('bg-blue-600', 'text-white');
-            likesButton.classList.remove('bg-blue-600', 'text-white');
-        });
-
-        likesButton.addEventListener('click', function () {
-            ownPosts.style.display = 'none';
+        } else if (button === likesButton) {
             likedPosts.style.display = 'block';
-            likesButton.classList.add('bg-blue-600', 'text-white');
-            ownButton.classList.remove('bg-blue-600', 'text-white');
-        });
+        }
+    }
+
+    // 初期表示
+    if (ownPosts.style.display === 'block') {
+        setActive(ownButton);
+    } else {
+        setActive(likesButton);
+    }
+
+    ownButton.addEventListener('click', function () {
+        setActive(ownButton);
     });
+
+    likesButton.addEventListener('click', function () {
+        setActive(likesButton);
+    });
+});
+
 </script>
+
+@push('styles')
+    <style>
+        .tab-button {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem; /* Tailwindの gap-2 = 0.5rem */
+    padding: 0.75rem 1.25rem; /* py-3=12px(0.75rem), px-5=20px(1.25rem) */
+    font-size: 0.875rem; /* text-sm */
+    font-weight: 600; /* font-semibold */
+    color: white;
+    background-color: #fb923c; /* Tailwind orange-400 (#fb923c) */
+    border-radius: 9999px; /* rounded-full */
+    box-shadow: 0 4px 6px rgba(0,0,0,0.1); /* shadow-md相当 */
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+    outline: none;
+  }
+
+  .tab-button:hover {
+      background-color: #f97316; /* orange-500 */
+      transform: scale(1.05);
+  }
+
+  .tab-button:focus {
+      outline: none;
+  }
+
+  .tab-button.active {
+      background-color: #ea580c; /* ちょっと濃いオレンジ */
+      color: white;
+  }
+      </style>
+    @endpush
   
 </x-app-layout>


### PR DESCRIPTION
・マイページで自分の記事といいねした記事を切り替えるとき、ページの再読み込みしなくてもできるようにしました
・ランキング画面と、マイページの記事選ぶ画面のボタンを見やすく、同じデザインにしました