### PR TITLE
マイページの記事遷移

### DIFF
--- a/src/resources/views/components/primary-button.blade.php
+++ b/src/resources/views/components/primary-button.blade.php
@@ -1,3 +1,4 @@
-<button {{ $attributes->merge(['class' => 'flex items-center gap-2 px-5 py-3 text-sm font-semibold text-white bg-orange-400 rounded-full shadow-md hover:bg-orange-500 hover:scale-105 transition-all duration-200 focus:outline-none']) }}>
+<button {{ $attributes->merge(['type' => 'button', 'class' => 'flex items-center gap-2 px-5 py-3 text-sm font-semibold text-white bg-orange-400 rounded-full shadow-md hover:bg-orange-500 hover:scale-105 transition-all duration-200 focus:outline-none']) }}>
     {{ $slot }}
 </button>
+

--- a/src/resources/views/mypage.blade.php
+++ b/src/resources/views/mypage.blade.php
@@ -82,10 +82,10 @@
     <span class="text-5xl">🍎</span>
     <span class="text-5xl">🍎</span>
 
-<x-primary-button 
-  class="tab-button" id="ownTabButton">
-  自分の投稿
-</x-primary-button>
+    <x-primary-button 
+      class="tab-button" id="ownTabButton">
+      自分の投稿
+    </x-primary-button>
 
     <x-primary-button id="likesTabButton"
         class="text-xl px-12 py-4 border transition-all tab-button {{ $viewMode === 'likes' ? 'bg-blue-600 text-white' : '' }}">


### PR DESCRIPTION
・マイページの切り替えをスムーズにするために、プライマリーボタンの定義を
primary-button.blade.php を以下のように 必ず type="button" を明記して修正してください：

<button {{ $attributes->merge(['type' => 'button', 'class' => 'flex items-center gap-2 px-5 py-3 text-sm font-semibold text-white bg-orange-400 rounded-full shadow-md hover:bg-orange-500 hover:scale-105 transition-all duration-200 focus:outline-none']) }}>
    {{ $slot }}
</button>

のように、既存のコードに'type' => 'button'を書き加えました