### PR TITLE
マイページに公開非公開のステータス表示

### DIFF
--- a/src/resources/views/mypage.blade.php
+++ b/src/resources/views/mypage.blade.php
@@ -113,6 +113,16 @@
                       <span>🍎</span>
                     @endif
                     投稿日: {{ $board->created_at->format('Y/m/d H:i') }}
+
+                    {{-- ここにステータス表示を追加 --}}
+                  <span class="ml-4 font-semibold">
+                    ステータス: 
+                    @if($board->is_published)
+                      <span class="text-green-600">公開中</span>
+                    @else
+                      <span class="text-red-600">非公開中</span>
+                    @endif
+                  </span>
                   </div>
                   <div class="prose prose-gray max-w-none">
                   @php


### PR DESCRIPTION
・マイページの自分の投稿した記事のとこに公開非公開のステータスが乗るようにしました