### PR TITLE
Hokaprofile

### DIFF
--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -47,10 +47,16 @@ class UserController extends Controller
 
     public function show(User $user)
     {
-        $boards = Board::where('user_id', $user->id)
-                            ->orderBy('created_at', 'desc')
-                            ->paginate(10);
-                   
+        $query = Board::where('user_id', $user->id)
+                    ->orderBy('created_at', 'desc');
+
+        if (auth()->id() !== $user->id) {
+            $query->where('is_published', true);
+        }
+
+        $boards = $query->paginate(10);
+
         return view('user.show', compact('user', 'boards'));
     }
+
 }

--- a/src/resources/views/profile/followers.blade.php
+++ b/src/resources/views/profile/followers.blade.php
@@ -13,11 +13,11 @@
                         @else
                             <i class="ri-user-3-line text-orange-400 text-2xl"></i>
                         @endif
-                        <a href="{{ route('profile.show', $follower->id) }}" class="text-lg font-semibold text-gray-700 hover:underline">
+                        <a href="{{ route('user.show', $follower->id) }}" class="text-lg font-semibold text-gray-700 hover:underline">
                             {{ $follower->name }}
                         </a>
                     </div>
-                    <a href="{{ route('profile.show', $follower->id) }}" class="text-xs text-white bg-orange-400 px-3 py-1 rounded-full shadow hover:bg-orange-500 transition-all duration-200">
+                    <a href="{{ route('user.show', $follower->id) }}" class="text-xs text-white bg-orange-400 px-3 py-1 rounded-full shadow hover:bg-orange-500 transition-all duration-200">
                         プロフィールを見る
                     </a>
                 </div>

--- a/src/resources/views/profile/followings.blade.php
+++ b/src/resources/views/profile/followings.blade.php
@@ -13,11 +13,11 @@
                         @else
                             <i class="ri-user-3-line text-orange-400 text-2xl"></i>
                         @endif
-                    <a href="{{ route('profile.show', $following->id) }}" class="text-lg font-semibold text-gray-700 hover:underline">
+                    <a href="{{ route('user.show', $following->id) }}" class="text-lg font-semibold text-gray-700 hover:underline">
                         {{ $following->name }}
                     </a>
                 </div>
-                <a href="{{ route('profile.show', $following->id) }}" class="text-xs text-white bg-orange-400 px-3 py-1 rounded-full shadow hover:bg-orange-500 transition-all duration-200">
+                <a href="{{ route('user.show', $following->id) }}" class="text-xs text-white bg-orange-400 px-3 py-1 rounded-full shadow hover:bg-orange-500 transition-all duration-200">
                     プロフィールを見る
                 </a>
             </div>


### PR DESCRIPTION
・ほかユーザーのプロフィール画面に非公開記事が出ないようにしました
・フォローフォロワー関連のbladeファイルの、
　  <a href="{{ route('user.show', $follower->id) }}" class="text-lg font-semibold text-gray-700 hover:underline">
                            {{ $follower->name }}
                        </a>
                    </div>
                    <a href="{{ route('user.show', $follower->id) }}" class="text-xs text-white bg-orange-400 px-3 py-1 rounded-full shadow hover:bg-orange-500 transition-all duration-200">
                        プロフィールを見る
                    </a>

このへんのprofile.showだったとこuser.showに変更しました（このままだとprofile.showに遷移されて、そのせいで非公開記事見えちゃってたからほかのページと同じようにほかユーザーのプロフ言ったらuser.showに遷移するようにした